### PR TITLE
Add simple tutorial and build docs with entity graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ Statically typed bare-metal HTML, CSS, and JavaScript framework for Scala.
 [An Introduction to Hyperscala](http://www.matthicks.com/2013/01/hyperscala-introduction.html)
 
 [ScalaDocs](http://build.sgine.org/job/hyperscala/javadoc)
+
+[Tutorial](tutorial.md)

--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Statically typed bare-metal HTML, CSS, and JavaScript framework for Scala.
 
 [ScalaDocs](http://build.sgine.org/job/hyperscala/javadoc)
 
-[Tutorial](tutorial.md)
+[Tutorial](tutorial/tutorial.md)

--- a/project/HyperScalaBuild.scala
+++ b/project/HyperScalaBuild.scala
@@ -27,6 +27,7 @@ object HyperScalaBuild extends Build {
     ),
     fork := true,
     scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature"),
+    scalacOptions in (Compile,doc) ++= Seq("-groups", "-implicits", "-diagrams", "-diagrams-dot-restart", "500"),
     resolvers ++= Seq("Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
                       "twitter-repo" at "http://maven.twttr.com",
                       "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"),

--- a/tutorial.md
+++ b/tutorial.md
@@ -1,0 +1,133 @@
+# Hyperscala Tutorial
+
+This tutorial is based on two blog articles and the [Hyperscala](http://www.hyperscala.org) 
+sources.
+
+- [Getting Started][1]
+- [An Introduction to Hyperscala][2]
+
+## What is it?
+
+Hyperscala is a Scala web framework providing type-safe HTML, CSS, SVG, and JavaScript.  It is 
+designed to eliminate the need for and confusion created by special UI templates.  Presentation 
+layer content can be rendered completely from Scala sources or read dynamically from files.  
+
+It provides a mechanism to deliver re-usable content in a simple, rich, and modular way. Hyperscala does 
+these things without requiring proprietary configuration files and without making decisions for you.
+
+## Quick Start
+
+The hyperscala sources contain numerous examples.  Look for examples here:
+
+- [Hyperscala examples directory](https://github.com/darkfrog26/hyperscala/tree/master/examples/src/main/scala/org/hyperscala/examples "Hyperscala examples directory shown in github")
+  These examples are hosted online [here](http://hyperscala.com/examples.html "Hyperscala examples directory hosted online")
+
+- [Hello example](#helloexample)
+
+### [Hello example](id:helloexample)
+
+The following is based on the [hello example from the hyperscala sources](https://github.com/darkfrog26/hyperscala/tree/master/hello "A simple hyperscala hello example shown in github").
+ 
+
+#### Create a simple scala project manually or use a [giter8][3] template.
+
+Manually create a Scala, `sbt` project, or if you use [giter8][3] you could type the following at the command line and answer the prompts. 
+
+    $ g8 darkfrog26/hyperscala.g8
+
+Here are a couple of other templates. 
+
+- [mmynsted/hyperscala.g8](https://github.com/mmynsted/hyperscala.g8)
+
+- [sebnozzi/hyperscala.g8](https://github.com/sebnozzi/hyperscala.g8)
+
+#### Create a page to host.
+
+```scala
+import org.hyperscala.web.Webpage
+import org.hyperscala.html._
+
+class HelloPage extends Webpage(HelloSite) {
+  title := "Hello world page"
+  body.contents += new tag.H1(content = "Hello, World!")
+}
+```
+
+This sets the title, and adds a greeting in an `H1` tag to a page in the `HelloSite`, 
+hyperscala site.
+
+#### Create the site
+
+##### `web.xml` 
+  This example uses a `Jetty` container so create the `web.xml` as needed.  This would go into 
+  someplace like `src/main/webapp/WEB-INF/`.
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app
+xmlns="http://java.sun.com/xml/ns/javaee"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+version="3.0"
+>
+<servlet>
+<servlet-name>outrnet</servlet-name>
+<servlet-class>com.outr.net.http.servlet.OUTRNetServlet</servlet-class>
+<init-param>
+<param-name>application</param-name>
+<param-value>hello.HelloSite</param-value>
+</init-param>
+<load-on-startup>1</load-on-startup>
+</servlet>
+<servlet-mapping>
+<servlet-name>outrnet</servlet-name>
+<url-pattern>/*</url-pattern>
+</servlet-mapping>
+<session-config>
+<session-timeout>25</session-timeout>
+</session-config>
+</web-app>
+```
+
+##### Create the Site
+
+Create something like the following.
+
+```scala
+import org.hyperscala.web.{StaticWebsite, BasicWebsite}
+import com.outr.net.http.jetty.JettyApplication
+import com.outr.net.http.session.MapSession
+
+object HelloSite extends BasicWebsite with StaticWebsite[MapSession] with JettyApplication {
+  def index = new HelloPage
+}
+```
+
+This creates a `HelloSite` site that will take requests at `index.html` and the root of the site 
+as expected.  If you add `def foo = new HelloPage` then a `HelloPage` will answer at `foo.html`...
+
+`BasicWebsite` extends [com.outr.net.http.WebApplication](https://github.com/darkfrog26/outrnet/blob/master/core/src/main/scala/com/outr/net/http/WebApplication.scala).
+The `outr.net` library is found [here](https://github.com/darkfrog26/outrnet).
+
+#### Try it
+
+Run with from sbt with the following.
+
+    $ sbt run
+
+## Modules
+
+
+
+## Dynamic Content
+
+## Putting it All Together
+
+## Where Do I Go from Here? 
+
+
+- - -
+
+[1]: http://www.matthicks.com/2013/01/hyperscala-getting-started.html "matthicks.com: Hyperscala Getting Started"
+[2]: http://www.matthicks.com/2013/01/hyperscala-introduction.html "matthicks.com: Hyperscala Introduction"
+[3]: https://github.com/n8han/giter8 "giter8 template repository on github"

--- a/tutorial.md
+++ b/tutorial.md
@@ -58,40 +58,8 @@ hyperscala site.
 
 #### Create the site
 
-##### `web.xml` 
-  This example uses a `Jetty` container so create the `web.xml` as needed.  This would go into 
-  someplace like `src/main/webapp/WEB-INF/`.
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<web-app
-xmlns="http://java.sun.com/xml/ns/javaee"
-xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-version="3.0"
->
-<servlet>
-<servlet-name>outrnet</servlet-name>
-<servlet-class>com.outr.net.http.servlet.OUTRNetServlet</servlet-class>
-<init-param>
-<param-name>application</param-name>
-<param-value>hello.HelloSite</param-value>
-</init-param>
-<load-on-startup>1</load-on-startup>
-</servlet>
-<servlet-mapping>
-<servlet-name>outrnet</servlet-name>
-<url-pattern>/*</url-pattern>
-</servlet-mapping>
-<session-config>
-<session-timeout>25</session-timeout>
-</session-config>
-</web-app>
-```
-
-##### Create the Site
-
-Create something like the following.
+This example uses a `Jetty` container so but you can leave the `webapp` directory empty.  Create 
+something like the following.
 
 ```scala
 import org.hyperscala.web.{StaticWebsite, BasicWebsite}

--- a/tutorial/snapshots.md
+++ b/tutorial/snapshots.md
@@ -1,0 +1,22 @@
+## Working with Snapshots
+
+The default mechanism for sbt to cache build products is with a local [ivy](http://ant.apache.org/ivy/) cache, e.g. 
+`~/.ivy2/cache/`.
+
+Ivy does not understand or handle snapshot builds well, so one must manually remove a locally published/cached 
+library when switching between using a released version and a snapshot version.  
+
+To use hyperscala from a snapshot one should do the following.
+
+0. Locally clone [powerscala](https://github.com/darkfrog26/power), then from the clone, `sbt publishLocal`.
+
+0. Locally clone [outrnet](https://github.com/darkfrog26/outrnet), then from the clone, `sbt publishLocal`.
+
+0. Locally clone [hyperscala](https://github.com/darkfrog26/hyperscala), then from the clone, `sbt publishLocal`.
+
+You may wish to build local versions of the docs while you are in these. The hyperscala project contains many 
+sub projects so to build a unified set of local docs you should `sbt unidoc`.  
+
+If you later need to work with a non-snapshot, or different snapshot release of a given library, you will need to 
+remove the library from the local ivy cache, so the correct version is cached.  
+

--- a/tutorial/tutorial.md
+++ b/tutorial/tutorial.md
@@ -1,0 +1,156 @@
+# Hyperscala Tutorial
+
+This tutorial is based on two blog articles and the [Hyperscala](http://www.hyperscala.org) 
+sources.
+
+- [Getting Started][1]
+- [An Introduction to Hyperscala][2]
+
+## What is it?
+
+Hyperscala is a Scala web framework providing type-safe HTML, CSS, SVG, and JavaScript.  It is 
+designed to eliminate the need for and confusion created by special UI templates.  Presentation 
+layer content can be rendered completely from Scala sources or read dynamically from files.  
+
+It provides a mechanism to deliver re-usable content in a simple, rich, and modular way. Hyperscala does 
+these things without requiring proprietary configuration files and without making decisions for you.
+
+## Quick Start
+
+The hyperscala sources contain numerous examples.  Look for examples here:
+
+- [Hyperscala examples directory](https://github.com/darkfrog26/hyperscala/tree/master/examples/src/main/scala/org/hyperscala/examples "Hyperscala examples directory shown in github")
+  These examples are hosted online [here](http://hyperscala.com/examples.html "Hyperscala examples directory hosted online")
+
+- [Hello example](#helloexample)
+
+### [Hello example](id:helloexample)
+
+The following is based on the [hello example from the hyperscala sources](https://github.com/darkfrog26/hyperscala/tree/master/hello "A simple hyperscala hello example shown in github") using 
+hyperscala version `0.9.3-SNAPSHOT`.  Please see [snapshots](snapshots.md) for more detail about using hyperscala snapshot versions. 
+ 
+
+#### Create a simple scala project manually or use a [giter8][3] template.
+
+Manually create a Scala, `sbt` project, or if you use [giter8][3] you could type the following at the command line and answer the prompts. 
+
+    $ g8 darkfrog26/hyperscala.g8
+
+Here are a couple of other templates. 
+
+- [mmynsted/hyperscala.g8](https://github.com/mmynsted/hyperscala.g8)
+
+- [sebnozzi/hyperscala.g8](https://github.com/sebnozzi/hyperscala.g8)
+
+#### Create a page to host.
+
+```scala
+import org.hyperscala.web.Webpage
+import org.hyperscala.html._
+
+class HelloPage extends Webpage(HelloSite) {
+  title := "Hello world page"
+  body.contents += new tag.H1(content = "Hello, World!")
+}
+```
+
+This sets the title, and adds a greeting in an `H1` tag to a page in the `HelloSite`, 
+hyperscala site.
+
+#### Create the site
+
+This example uses a `Jetty` container so but you can leave the `webapp` directory empty.  Create 
+something like the following.
+
+```scala
+import org.hyperscala.web.{StaticWebsite, BasicWebsite}
+import com.outr.net.http.jetty.JettyApplication
+import com.outr.net.http.session.MapSession
+
+object HelloSite extends BasicWebsite with StaticWebsite[MapSession] with JettyApplication {
+  def index = new HelloPage
+}
+```
+
+This creates a `HelloSite` site that will take requests at `index.html` and the root of the site 
+as expected.  If you add `def foo = new HelloPage` then a `HelloPage` will answer at `foo.html`...
+
+`BasicWebsite` extends [com.outr.net.http.WebApplication](https://github.com/darkfrog26/outrnet/blob/master/core/src/main/scala/com/outr/net/http/WebApplication.scala).
+The `outr.net` library is found [here](https://github.com/darkfrog26/outrnet).
+
+#### Try it
+
+Run with from sbt with the following.
+
+    $ sbt run
+
+## Modules
+
+The following is a simple module to provide a particular version of `jQuery` to a page.  First put a jQuery file named 
+`jquery-1.8.2.min.js` in a `resources` directory.
+
+Example:  
+`src/main/resources/jquery-1.8.2.min.js`
+
+Then create a new module, such as `jquery182.scala`.  I could look like the following.
+
+
+```scala
+import org.hyperscala.html.tag
+import org.hyperscala.web.{Website,Webpage}
+import org.powerscala.Version
+import org.hyperscala.module._
+
+object jQuery182 extends Module {
+
+  import com.outr.net.http.session.Session
+
+  def name = "jQuery182"
+  def version = Version(1,8,2)
+
+  override def init[S <: Session](website: Website[S]) = {
+    website.register("/js/jquery-1.8.2.js", "jquery-1.8.2.min.js")
+  }
+
+  override def load[S <: Session](webpage: Webpage[S]) = {
+    webpage.head.contents += new tag.Script(mimeType = "text/javascript", src = "/js/jquery-1.8.2.js")
+  }
+
+}
+```
+
+Then alter your page to include `require(jQuery182)`.  It might look like this.
+
+```scala
+import org.hyperscala.web.Webpage
+import org.hyperscala.html._
+
+class HelloPage extends Webpage(HelloSite) {
+  require(jQuery182)
+  title := "Hello world page"
+  body.contents += new tag.H1(content = "Hello, ")
+  body.contents += new tag.H2(content = "World!")
+}
+```
+
+Then when you try it you can view source and see that your `jQuery182` resource was included as a javascript file in the `HEAD`. 
+
+    <head>
+      <title>Hello world page</title>
+      <meta name="generator" content="Hyperscala"/>
+      <meta charset="UTF-8"/>
+      <script type="text/javascript" src="/js/jquery-1.8.2.js"></script>
+    </head>
+
+## Dynamic Content
+
+## Putting it All Together
+
+## Where Do I Go from Here? 
+
+
+- - -
+
+[1]: http://www.matthicks.com/2013/01/hyperscala-getting-started.html "matthicks.com: Hyperscala Getting Started"
+[2]: http://www.matthicks.com/2013/01/hyperscala-introduction.html "matthicks.com: Hyperscala Introduction"
+[3]: https://github.com/n8han/giter8 "giter8 template repository on github"

--- a/tutorial/tutorial.md
+++ b/tutorial/tutorial.md
@@ -145,7 +145,7 @@ class DynamicContentExample extends Webpage(HelloSite) {
     val button = load[tag.Button]("b1")
     button.clickEvent := RealtimeEvent()
     button.clickEvent.on {
-      //Replace person with a one with new values on button click.
+      //Replace person with one with new values on button click.
       case evt => person := Person("Test User", 987)
     }
 


### PR DESCRIPTION
The correct version of the tutorial is in a `tutorial` directory under the project root. 
The entity graphs require a graphviz install.  Some graphs fail during build and thus graphviz must be automatically restarted.  This is not unusual.  I have bumped up the number of restarts to permit each sub project to build correctly, and also so a unified doc can complete.  I just set it in one place, to a high value.  
 